### PR TITLE
chore: Tell Stale bot to only mark as stale, but not close

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,12 +1,10 @@
 # Number of days of inactivity before an issue becomes stale
 daysUntilStale: 30
 # Number of days of inactivity before a stale issue is closed
-daysUntilClose: 30
+daysUntilClose: false
 # Issues with these labels will never be considered stale
 exemptLabels:
   - pinned
-  - Bug
-  - Long Term
 # Label to use when marking an issue as stale
 staleLabel: Stale
 # Comment to post when marking an issue as stale. Set to `false` to disable


### PR DESCRIPTION
Since we're down to about 25 issues open right now, I think we could try switching off auto-closing of stale issues by the bot. With this configuration, it would still mark issues/PRs as stale after 30 days, but not close them. In combination with this I would also remove the exemption for labels `Bug` and `Long Term`, which should be fine to label as stale but won't be closed anyway with this configuration.

Thoughts?
