### PR TITLE
Fixed initialization issue in centroid estimation for multiple surface layer

### DIFF
--- a/Core/src/Geometry/CuboidVolumeBuilder.cpp
+++ b/Core/src/Geometry/CuboidVolumeBuilder.cpp
@@ -66,7 +66,7 @@ std::shared_ptr<const Acts::Layer> Acts::CuboidVolumeBuilder::buildLayer(
     }
   }
   // Build transformation centered at the surface position
-  Vector3 centroid;
+  Vector3 centroid{0.,0.,0.};
 
   for (const auto& surface : cfg.surfaces) {
     centroid += surface->transform(gctx).translation();


### PR DESCRIPTION
Just fixed an initialization issue. This fixes the layers location in the case of multiple surfaces per layer in the cuboid builder