### PR TITLE
ci: Use `needs` in GitLab CI to speed up job scheduling

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -85,7 +85,7 @@ build:
 
 test:
   stage: test
-  dependencies:
+  needs:
     - build
   image: ghcr.io/acts-project/ubuntu2004_exatrkx:v26
   tags:


### PR DESCRIPTION
This is currently using `dependencies` which blocks until the previous stage is complete.